### PR TITLE
add email validation for the cleintEmail configuration field

### DIFF
--- a/config/general_test.go
+++ b/config/general_test.go
@@ -80,6 +80,16 @@ func TestParseGeneral(t *testing.T) {
 			expectedErr: multierr.Combine(validator.RequiredErr(models.ConfigClientEmail),
 				validator.RequiredErr(models.ConfigProjectID)).Error(),
 		},
+		{
+			name: "invalid email",
+			in: map[string]string{
+				models.ConfigPrivateKey:  "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail: "test-pubsub.com",
+				models.ConfigProjectID:   "test-pubsub",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidEmailErr(models.ConfigClientEmail).Error(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/config/validator/consts.go
+++ b/config/validator/consts.go
@@ -1,0 +1,28 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+const (
+	googPrefix = "goog"
+
+	requiredErrMsg     = "%q value must be set"
+	invalidEmailErrMsg = "%q value must be a valid email address"
+	invalidNameErrMsg  = "%q must be 3-255 characters, start with a letter, and contain only the following characters: " +
+		"letters, numbers, dashes (-), periods (.), underscores (_), tildes (~), percents (%%) or plus signs (+). " +
+		"Cannot start with goog"
+	invalidIntegerTypeErrMsg  = "%q value must be an integer"
+	invalidTimeDurationErrMsg = "%q value must be a time duration"
+	outOfRangeErrMsg          = "%q is out of range"
+)

--- a/config/validator/errors.go
+++ b/config/validator/errors.go
@@ -16,31 +16,32 @@ package validator
 
 import "fmt"
 
-const invalidNameErrMsg = "must be 3-255 characters, start with a letter, and contain only the following characters: " +
-	"letters, numbers, dashes (-), periods (.), underscores (_), tildes (~), percents (%) or plus signs (+). " +
-	"Cannot start with goog."
-
 // RequiredErr returns the formatted required field error.
 func RequiredErr(name string) error {
-	return fmt.Errorf("%q value must be set", name)
+	return fmt.Errorf(requiredErrMsg, name)
+}
+
+// InvalidEmailErr returns the formatted email field error.
+func InvalidEmailErr(name string) error {
+	return fmt.Errorf(invalidEmailErrMsg, name)
 }
 
 // InvalidNameErr returns the formatted invalid name error.
 func InvalidNameErr(name string) error {
-	return fmt.Errorf("%q %s", name, invalidNameErrMsg)
+	return fmt.Errorf(invalidNameErrMsg, name)
 }
 
 // InvalidIntegerTypeErr returns the formatted invalid integer type error.
 func InvalidIntegerTypeErr(name string) error {
-	return fmt.Errorf("%q value must be an integer", name)
+	return fmt.Errorf(invalidIntegerTypeErrMsg, name)
 }
 
 // InvalidTimeDurationTypeErr returns the formatted invalid time duration type error.
 func InvalidTimeDurationTypeErr(name string) error {
-	return fmt.Errorf("%q value must be a time duration", name)
+	return fmt.Errorf(invalidTimeDurationErrMsg, name)
 }
 
 // OutOfRangeErr returns the formatted out of range error.
 func OutOfRangeErr(name string) error {
-	return fmt.Errorf("%q is out of range", name)
+	return fmt.Errorf(outOfRangeErrMsg, name)
 }

--- a/config/validator/validator.go
+++ b/config/validator/validator.go
@@ -25,8 +25,6 @@ import (
 	"go.uber.org/multierr"
 )
 
-const googPrefix = "goog"
-
 var (
 	validatorInstance *v.Validate
 	once              sync.Once
@@ -61,6 +59,8 @@ func Validate(s interface{}) error {
 			switch e.ActualTag() {
 			case "required":
 				err = multierr.Append(err, RequiredErr(models.ConfigKeyName(e.Field())))
+			case "email":
+				err = multierr.Append(err, InvalidEmailErr(models.ConfigKeyName(e.Field())))
 			case "object_name":
 				err = multierr.Append(err, InvalidNameErr(models.ConfigKeyName(e.Field())))
 			case "gte", "lte":


### PR DESCRIPTION
### Description

A new validation rule for the configuration `emailClient` field was added. In case of an invalid email, the user will receive the error message `clientEmail value must be a valid email address`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-gcp-pubsub/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
