### PR TITLE
Update validation rules for topicId and subscriptionId

### DIFF
--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -97,6 +97,17 @@ func TestParseDestination(t *testing.T) {
 			expectedErr: validator.InvalidNameErr(models.ConfigTopicID).Error(),
 		},
 		{
+			name: "topic id does not start with a letter",
+			in: map[string]string{
+				models.ConfigPrivateKey:  "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail: "test@test-pubsub.com",
+				models.ConfigProjectID:   "test-pubsub",
+				models.ConfigTopicID:     "1-test-top*",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigTopicID).Error(),
+		},
+		{
 			name: "topic id has unsupported characters",
 			in: map[string]string{
 				models.ConfigPrivateKey:  "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
@@ -114,6 +125,28 @@ func TestParseDestination(t *testing.T) {
 				models.ConfigClientEmail: "test@test-pubsub.com",
 				models.ConfigProjectID:   "test-pubsub",
 				models.ConfigTopicID:     "goog-test-topic",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigTopicID).Error(),
+		},
+		{
+			name: "topic id starts with Goog",
+			in: map[string]string{
+				models.ConfigPrivateKey:  "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail: "test@test-pubsub.com",
+				models.ConfigProjectID:   "test-pubsub",
+				models.ConfigTopicID:     "Goog-test-topic",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigTopicID).Error(),
+		},
+		{
+			name: "topic id starts with gooG",
+			in: map[string]string{
+				models.ConfigPrivateKey:  "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail: "test@test-pubsub.com",
+				models.ConfigProjectID:   "test-pubsub",
+				models.ConfigTopicID:     "gooG-test-topic",
 			},
 			wantErr:     true,
 			expectedErr: validator.InvalidNameErr(models.ConfigTopicID).Error(),

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -72,6 +72,17 @@ func TestParseSource(t *testing.T) {
 			expectedErr: validator.InvalidNameErr(models.ConfigSubscriptionID).Error(),
 		},
 		{
+			name: "subscription id does not start with a letter",
+			in: map[string]string{
+				models.ConfigPrivateKey:     "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail:    "test@test-pubsub.com",
+				models.ConfigProjectID:      "test-pubsub",
+				models.ConfigSubscriptionID: "1-test-subscription",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigSubscriptionID).Error(),
+		},
+		{
 			name: "subscription id has unsupported characters",
 			in: map[string]string{
 				models.ConfigPrivateKey:     "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
@@ -89,6 +100,28 @@ func TestParseSource(t *testing.T) {
 				models.ConfigClientEmail:    "test@test-pubsub.com",
 				models.ConfigProjectID:      "test-pubsub",
 				models.ConfigSubscriptionID: "goog-test-subscription",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigSubscriptionID).Error(),
+		},
+		{
+			name: "subscription id starts with Goog",
+			in: map[string]string{
+				models.ConfigPrivateKey:     "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail:    "test@test-pubsub.com",
+				models.ConfigProjectID:      "test-pubsub",
+				models.ConfigSubscriptionID: "Goog-test-subscription",
+			},
+			wantErr:     true,
+			expectedErr: validator.InvalidNameErr(models.ConfigSubscriptionID).Error(),
+		},
+		{
+			name: "subscription id starts with gooG",
+			in: map[string]string{
+				models.ConfigPrivateKey:     "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADAQEFAASC-----END PRIVATE KEY-----",
+				models.ConfigClientEmail:    "test@test-pubsub.com",
+				models.ConfigProjectID:      "test-pubsub",
+				models.ConfigSubscriptionID: "gooG-test-subscription",
 			},
 			wantErr:     true,
 			expectedErr: validator.InvalidNameErr(models.ConfigSubscriptionID).Error(),

--- a/config/validator/validator.go
+++ b/config/validator/validator.go
@@ -29,7 +29,7 @@ var (
 	validatorInstance *v.Validate
 	once              sync.Once
 
-	isObjectNameOK = regexp.MustCompile(`^[a-zA-Z\d-._~%+]{3,255}$`).MatchString
+	isObjectNameValid = regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d-._~%+]{2,254}$`).MatchString
 )
 
 // Get initializes and registers validation tags once, and returns validator instance.
@@ -73,9 +73,9 @@ func Validate(s interface{}) error {
 }
 
 func validateObjectName(fl v.FieldLevel) bool {
-	if strings.HasPrefix(fl.Field().String(), googPrefix) {
+	if strings.HasPrefix(strings.ToLower(fl.Field().String()), googPrefix) {
 		return false
 	}
 
-	return isObjectNameOK(fl.Field().String())
+	return isObjectNameValid(fl.Field().String())
 }


### PR DESCRIPTION
### Description

Configuration fields `topicId` and `subscriptionId` must not begin with:
- `goog` in any cases;
- anything except a letter.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-gcp-pubsub/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
