### PR TITLE
Update a module name from conduit repository to conduit-labs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Fixes # (issue)
 
 ### Quick checks:
 
-- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
-- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-gcp-pubsub/pulls) for the same update/change.
+- [ ] I have followed the [Code Guidelines](https://github.com/conduitio/conduit/blob/main/docs/code_guidelines.md).
+- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-gcp-pubsub/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/google/uuid"
 	"go.uber.org/goleak"

--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
 	"google.golang.org/api/option"
 )
 

--- a/client/publisher.go
+++ b/client/publisher.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/client/subscriber.go
+++ b/client/subscriber.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/gammazero/deque"
 )

--- a/cmd/gcppubsub/main.go
+++ b/cmd/gcppubsub/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	gcppubsub "github.com/conduitio/conduit-connector-gcp-pubsub"
+	gcppubsub "github.com/conduitio-labs/conduit-connector-gcp-pubsub"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/config/destination.go
+++ b/config/destination.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 // A Destination represents a destination configuration needed for the publisher client.

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 func TestParseDestination(t *testing.T) {

--- a/config/general.go
+++ b/config/general.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 // A General represents a general configuration needed for GCP Pub/Sub client.

--- a/config/general_test.go
+++ b/config/general_test.go
@@ -18,8 +18,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	"go.uber.org/multierr"
 )
 

--- a/config/source.go
+++ b/config/source.go
@@ -15,8 +15,8 @@
 package config
 
 import (
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 // A Source represents a source configuration needed for the subscriber client.

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -18,8 +18,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 func TestParseSource(t *testing.T) {

--- a/config/validator/validator.go
+++ b/config/validator/validator.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	v "github.com/go-playground/validator/v10"
 	"go.uber.org/multierr"
 )

--- a/connector.go
+++ b/connector.go
@@ -15,8 +15,8 @@
 package gcppubsub
 
 import (
-	"github.com/conduitio/conduit-connector-gcp-pubsub/destination"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/source"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/destination"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/source"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -17,8 +17,8 @@ package destination
 import (
 	"context"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/client"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/client"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/google/uuid"
 	"go.uber.org/goleak"

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 func TestDestination_Configure(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/conduitio/conduit-connector-gcp-pubsub
+module github.com/conduitio-labs/conduit-connector-gcp-pubsub
 
 go 1.18
 
 require (
 	cloud.google.com/go/pubsub v1.22.2
-	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220530152250-733149cddc0b
+	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220607154716-0655cdd93a58
 	github.com/gammazero/deque v0.2.0
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/conduitio/conduit-connector-protocol v0.2.0 h1:gwYXVKEMgTtU67ephQ5WwTGIDbT/eTLA9Mdr9Bnbqxc=
 github.com/conduitio/conduit-connector-protocol v0.2.0/go.mod h1:udCU2AkLcYQoLjAO06tHVL2iFJPw+DamK+wllnj50hk=
-github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220530152250-733149cddc0b h1:KULsrkk4m0CXWDrkgOBHUaXKQl/eSYVqCNtPTHmV6Ws=
-github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220530152250-733149cddc0b/go.mod h1:1rf6zsSIcrmUGkuGNOQNdRIcXoqPx8Xh/cYJ1h1vFp4=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220607154716-0655cdd93a58 h1:aAbe4gsGnrX1f5bgOvrVIX5U6U5Cpff/bIV9QyfSx50=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220607154716-0655cdd93a58/go.mod h1:1rf6zsSIcrmUGkuGNOQNdRIcXoqPx8Xh/cYJ1h1vFp4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/source/source.go
+++ b/source/source.go
@@ -17,8 +17,8 @@ package source
 import (
 	"context"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/client"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/client"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/destination"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/destination"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/google/uuid"
 	"github.com/jpillora/backoff"

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -19,9 +19,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/config/validator"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/config/validator"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 )
 
 func TestSource_Configure(t *testing.T) {

--- a/spec.go
+++ b/spec.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/conduitio/conduit-connector-gcp-pubsub/models"
+	"github.com/conduitio-labs/conduit-connector-gcp-pubsub/models"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 


### PR DESCRIPTION
### Description

I used the wrong repository path in the module name.
So I've updated it to a new one.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-gcp-pubsub/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
