### PR TITLE
Remove a method `getPosition`

### DIFF
--- a/client/subscriber.go
+++ b/client/subscriber.go
@@ -97,13 +97,8 @@ func (s *Subscriber) Next(ctx context.Context) (sdk.Record, error) {
 
 		s.ackDeque.PushBack(msg)
 
-		position, err := s.getPosition()
-		if err != nil {
-			return sdk.Record{}, fmt.Errorf("get position: %w", err)
-		}
-
 		return sdk.Record{
-			Position:  position,
+			Position:  sdk.Position(uuid.New().String()),
 			Metadata:  msg.Attributes,
 			CreatedAt: msg.PublishTime,
 			Payload:   sdk.RawData(msg.Data),
@@ -150,14 +145,4 @@ func (s *Subscriber) Stop() error {
 	<-s.canceledCh
 
 	return s.pubSub.close()
-}
-
-// getPosition returns the current iterator position.
-func (*Subscriber) getPosition() (sdk.Position, error) {
-	uuidBytes, err := uuid.New().MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("marshal uuid: %w", err)
-	}
-
-	return uuidBytes, nil
 }


### PR DESCRIPTION
### Description

I've removed the method `getPosition`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-gcp-pubsub/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
