### PR TITLE
Update the name of connector

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -26,7 +26,7 @@ var version = "v0.0.0-dev"
 // Specification returns specification of the connector.
 func Specification() sdk.Specification {
 	return sdk.Specification{
-		Name:    "gcp-pub-sub",
+		Name:    "gcp-pubsub",
 		Summary: "A GCP Pub/Sub source and destination plugin for Conduit, written in Go.",
 		Description: "The Google Cloud Platform Pub/Sub connector is one of Conduit plugins. " +
 			"It provides a source and a destination GCP Pub/Sub and Pub/Sub Lite connector.",


### PR DESCRIPTION
### Description

I've updated the name of the connector (from `gcp-pub-sub` to `gcp-pubsub`).

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/conduitio/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-gcp-pubsub/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
